### PR TITLE
Quay: Switch away from Docker Hub to avoid issues with rate limiting

### DIFF
--- a/lib/kontena/machine/digital_ocean/cloudinit.yml
+++ b/lib/kontena/machine/digital_ocean/cloudinit.yml
@@ -7,7 +7,6 @@ write_files:
       KONTENA_URI=<%= master_uri %>
       KONTENA_TOKEN=<%= grid_token %>
       KONTENA_PEER_INTERFACE=eth1
-      KONTENA_VERSION=<%= version %>
   - path: /etc/systemd/system/docker.service.d/50-krates.conf
     content: |
         [Service]
@@ -76,11 +75,11 @@ coreos:
         EnvironmentFile=/etc/krates-worker.env
         ExecStartPre=-/usr/bin/docker stop krates-worker
         ExecStartPre=-/usr/bin/docker rm krates-worker
-        ExecStartPre=/usr/bin/docker pull krates/worker
+        ExecStartPre=/usr/bin/docker pull quay.io/krates/worker
         ExecStart=/usr/bin/docker run --name krates-worker \
             --env-file /etc/krates-worker.env \
             -v=/var/run/docker.sock:/var/run/docker.sock \
             -v=/etc/krates-worker.env:/etc/kontena.env \
             --net=host \
-            krates/worker
+            quay.io/krates/worker
         ExecStop=/usr/bin/docker stop krates-worker

--- a/lib/kontena/machine/digital_ocean/cloudinit_master.yml
+++ b/lib/kontena/machine/digital_ocean/cloudinit_master.yml
@@ -4,7 +4,6 @@ write_files:
     permissions: 0600
     owner: root
     content: |
-      KONTENA_VERSION=<%= version %>
       KONTENA_VAULT_KEY=<%= vault_secret %>
       KONTENA_VAULT_IV=<%= vault_iv %>
       <% if ssl_cert %>SSL_CERT="/etc/kontena-server.pem"
@@ -82,7 +81,7 @@ coreos:
         EnvironmentFile=-/etc/kontena-server.custom.env
         ExecStartPre=-/usr/bin/docker stop kontena-server-api
         ExecStartPre=-/usr/bin/docker rm kontena-server-api
-        ExecStartPre=-/usr/bin/docker pull krates/master:${KONTENA_VERSION}
+        ExecStartPre=-/usr/bin/docker pull quay.io/krates/master
         ExecStart=/usr/bin/docker run --name kontena-server-api \
 <% if mongodb_uri -%>
             -e MONGODB_URI=<%= mongodb_uri %> \
@@ -97,7 +96,7 @@ coreos:
             -e INITIAL_ADMIN_CODE=<%= initial_admin_code %> \
 <% end -%>
             -e VAULT_KEY=${KONTENA_VAULT_KEY} -e VAULT_IV=${KONTENA_VAULT_IV} \
-            krates/master:${KONTENA_VERSION}
+            quay.io/krates/master
         ExecStop=/usr/bin/docker stop kontena-server-api
 
     - name: krates-server-haproxy.service

--- a/lib/kontena/plugin/digital_ocean.rb
+++ b/lib/kontena/plugin/digital_ocean.rb
@@ -2,7 +2,7 @@
 module Kontena
   module Plugin
     module DigitalOcean
-      VERSION = "0.3.11"
+      VERSION = "0.3.12"
     end
   end
 end

--- a/spec/kontena/machine/digital_ocean/master_provisioner_spec.rb
+++ b/spec/kontena/machine/digital_ocean/master_provisioner_spec.rb
@@ -43,17 +43,17 @@ describe Kontena::Machine::DigitalOcean::MasterProvisioner do
         data = subject.run!(:name => 'xoxo')
       end
 
-      it "uses latest 'krates/master' image" do
+      it "uses latest 'quay.io/krates/master' image" do
         expect(droplet.user_data).to include('- name: krates-server-api.service')
-        expect(droplet.user_data).to include('krates/master:${KONTENA_VERSION}')
+        expect(droplet.user_data).to include('quay.io/krates/master')
         expect(droplet.user_data).to include('ExecStart=/usr/bin/docker run --name kontena-server-api \\')
       end
 
-      it "stops existing 'krates/master' container at stop" do
+      it "stops existing 'quay.io/krates/master' container at stop" do
         expect(droplet.user_data).to include('ExecStop=/usr/bin/docker stop kontena-server-api')
       end
 
-      it "stops and removes existing 'krates/master' container at pre-start" do
+      it "stops and removes existing 'quay.io/krates/master' container at pre-start" do
         expect(droplet.user_data).to include('ExecStartPre=-/usr/bin/docker stop kontena-server-api')
         expect(droplet.user_data).to include('ExecStartPre=-/usr/bin/docker rm kontena-server-api')
       end


### PR DESCRIPTION
 - Quay: Switch away from Docker Hub to avoid issues with rate limiting;
 - Krates: Unit files should upull the latest images for Master and Worker services;
 - Hookup 'krates/master' with 'cloudinit-master.yml' in DigitalOcean plugin;